### PR TITLE
Screen object

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir=
     =src
 packages = find:
 install_requires =
-    tslumd>=0.0.2
+    tslumd>=0.0.3
     gpiozero
     rgbmatrix5x5
     loguru

--- a/src/tallypi/cli.py
+++ b/src/tallypi/cli.py
@@ -10,10 +10,14 @@ from tallypi.common import (
 )
 from tallypi import outputs
 
-def build_single_tally_conf(tally_index, tally_type):
+def build_single_tally_conf(screen_index, tally_index, tally_type):
     if isinstance(tally_type, str):
         tally_type = getattr(TallyType, tally_type)
-    return SingleTallyConfig(tally_index=tally_index, tally_type=tally_type)
+    return SingleTallyConfig(
+        screen_index=screen_index,
+        tally_index=tally_index,
+        tally_type=tally_type,
+    )
 
 def add_object_to_config(obj: BaseIO):
     async def do_add():
@@ -70,22 +74,25 @@ def add_input():
 @add_input.command('umd')
 @click.option('-h', '--hostaddr', default='0.0.0.0')
 @click.option('-p', '--hostport', default=65000, type=int)
-def add_umd_input(hostaddr, hostport):
+@click.option('-s', '--screen-index', 'screen_index', required=False, type=int)
+def add_umd_input(hostaddr, hostport, screen_index):
     ns = 'input.umd.UmdInput'
     cls = BaseIO.get_class_for_namespace(ns)
-    tally_conf = MultiTallyConfig(allow_all=True)
+    tally_conf = MultiTallyConfig(allow_all=True, screen_index=screen_index)
     obj = cls(tally_conf, hostaddr, hostport)
     add_object_to_config(obj)
 
 @add.group('output')
+@click.option('-s', '--screen-index', 'screen_index', required=False, type=int)
 @click.option('-i', '--tally-index', 'tally_index', required=True, type=int)
 @click.option('-t', '--tally-type', 'tally_type', required=True, type=str)
 @click.pass_context
-def add_output(ctx, tally_index, tally_type):
+def add_output(ctx, screen_index, tally_index, tally_type):
     ctx.ensure_object(dict)
+    ctx.obj['screen_index'] = screen_index
     ctx.obj['tally_index'] = tally_index
     ctx.obj['tally_type'] = tally_type
-    ctx.obj['tally_conf'] = build_single_tally_conf(tally_index, tally_type)
+    ctx.obj['tally_conf'] = build_single_tally_conf(screen_index, tally_index, tally_type)
 
 @add_output.command('rgbmatrix')
 @click.argument('display_type', type=click.Choice(['indicator', 'matrix']))

--- a/src/tallypi/common.py
+++ b/src/tallypi/common.py
@@ -28,6 +28,10 @@ def normalize_screen(obj: Union[TallyOrMultiTallyConfig, int]) -> Union[None, in
         screen = obj.screen.index
         if obj.screen.is_broadcast:
             screen = None
+    elif isinstance(obj, Screen):
+        screen = obj.index
+        if obj.is_broadcast:
+            screen = None
     else:
         screen = obj.screen_index
         if obj.is_broadcast_screen:
@@ -326,7 +330,7 @@ class MultiTallyConfig(TallyConfig):
         if self.allow_all:
             return self.matches_screen(tally)
         for t in self.tallies:
-            if tally_conf.matches(t):
+            if t.matches(tally):
                 return True
         return False
 

--- a/src/tallypi/common.py
+++ b/src/tallypi/common.py
@@ -21,7 +21,9 @@ TallyOrTallyConfig = Union[Tally, 'SingleTallyConfig']
 TallyOrMultiTallyConfig = Union[TallyOrTallyConfig, 'MultiTallyConfig']
 
 def normalize_screen(obj: Union[TallyOrMultiTallyConfig, int]) -> Union[None, int]:
-    if isinstance(obj, int):
+    if obj is None:
+        return None
+    elif isinstance(obj, int):
         screen = obj
         if obj == 0xffff:
             screen = None

--- a/src/tallypi/common.py
+++ b/src/tallypi/common.py
@@ -730,4 +730,5 @@ class BaseOutput(BaseIO, namespace='output'):
         """
         loop = asyncio.get_event_loop()
         tally.bind_async(loop, on_update=self.on_receiver_tally_change)
-        await self.on_receiver_tally_change(tally)
+        props_changed = ('rh_tally', 'txt_tally', 'lh_tally')
+        await self.on_receiver_tally_change(tally, props_changed=props_changed)

--- a/src/tallypi/common.py
+++ b/src/tallypi/common.py
@@ -16,8 +16,15 @@ __all__ = (
 Pixel = Tuple[int, int] #: A tuple of ``(x, y)`` coordinates
 Rgb = Tuple[int, int, int] #: A color tuple of ``(r, g, b)``
 
-def normalize_screen(obj: Union[Tally, 'SingleTallyConfig', 'MultiTallyConfig']) -> Union[None, int]:
-    if isinstance(obj, Tally):
+TallyOrTallyConfig = Union[Tally, 'SingleTallyConfig']
+TallyOrMultiTallyConfig = Union[TallyOrTallyConfig, 'MultiTallyConfig']
+
+def normalize_screen(obj: Union[TallyOrMultiTallyConfig, int]) -> Union[None, int]:
+    if isinstance(obj, int):
+        screen = obj
+        if obj == 0xffff:
+            screen = None
+    elif isinstance(obj, Tally):
         screen = obj.screen.index
         if obj.screen.is_broadcast:
             screen = None
@@ -27,8 +34,12 @@ def normalize_screen(obj: Union[Tally, 'SingleTallyConfig', 'MultiTallyConfig'])
             screen = None
     return screen
 
-def normalize_tally_index(obj: Union[Tally, 'SingleTallyConfig']) -> Union[None, int]:
-    if isinstance(obj, Tally):
+def normalize_tally_index(obj: Union[TallyOrTallyConfig, int]) -> Union[None, int]:
+    if isinstance(obj, int):
+        ix = obj
+        if obj == 0xffff:
+            ix = None
+    elif isinstance(obj, Tally):
         ix = obj.index
         if obj.is_broadcast:
             ix = None
@@ -128,7 +139,7 @@ class SingleTallyConfig(TallyConfig):
             Option(name='name', type=str, required=False, default='', title='Name'),
         )
 
-    def matches(self, other: Union['SingleTallyConfig', Tally]) -> bool:
+    def matches(self, other: TallyOrTallyConfig) -> bool:
         """Determine whether the given tally argument matches this one
 
         For :attr:`screen_index` the :meth:`matches_screen` method is used
@@ -148,7 +159,7 @@ class SingleTallyConfig(TallyConfig):
             return True
         return self_ix == oth_ix
 
-    def matches_screen(self, other: Union['SingleTallyConfig', 'MultiTallyConfig', Tally]) -> bool:
+    def matches_screen(self, other: Union[TallyOrMultiTallyConfig, int]) -> bool:
         """Determine whether the :attr:`screen_index` matches the given argument
 
         For :class:`tslumd.tallyobj.Tally`, the
@@ -157,8 +168,8 @@ class SingleTallyConfig(TallyConfig):
         as well as cases where :attr:`screen_index` is set to ``None``
 
         Arguments:
-            other: A :class:`SingleTallyConfig`, :class:`MultiTallyConfig`
-                or :class:`tslumd.tallyobj.Tally` instance
+            other: A :class:`SingleTallyConfig`, :class:`MultiTallyConfig`,
+                :class:`tslumd.tallyobj.Tally` or :class:`int`
         """
         if self.is_broadcast_screen:
             return True
@@ -277,7 +288,7 @@ class MultiTallyConfig(TallyConfig):
         """
         return self.contains(tally)
 
-    def matches_screen(self, other: Union[SingleTallyConfig, 'MultiTallyConfig', Tally]) -> bool:
+    def matches_screen(self, other: Union[TallyOrMultiTallyConfig, int]) -> bool:
         """Determine whether the :attr:`screen_index` matches the given argument
 
         For :class:`tslumd.tallyobj.Tally`, the
@@ -286,8 +297,8 @@ class MultiTallyConfig(TallyConfig):
         as well as cases where :attr:`screen_index` is set to ``None``
 
         Arguments:
-            other: A :class:`SingleTallyConfig`, :class:`MultiTallyConfig`
-                or :class:`tslumd.tallyobj.Tally` instance
+            other: A :class:`SingleTallyConfig`, :class:`MultiTallyConfig`,
+                :class:`tslumd.tallyobj.Tally` or :class:`int`
 
         Note:
             Behavior is undefined if :attr:`allow_all` is ``False``
@@ -300,7 +311,7 @@ class MultiTallyConfig(TallyConfig):
             return self_screen == oth_screen
         return True
 
-    def contains(self, tally: Union[SingleTallyConfig, Tally]) -> bool:
+    def contains(self, tally: TallyOrTallyConfig) -> bool:
         """Determine whether the given tally argument is included in this
         configuration
 

--- a/src/tallypi/common.py
+++ b/src/tallypi/common.py
@@ -506,52 +506,6 @@ class BaseIO(Dispatcher):
             d[opt.name] = opt.serialize(value)
         return d
 
-    @property
-    def tally_index(self) -> int:
-        """Alias for :attr:`~SingleTallyConfig.tally_index` of the :attr:`config`
-
-        Note:
-            Only valid if :attr:`config` is a :class:`SingleTallyConfig`
-        """
-        if not isinstance(self.config, SingleTallyConfig):
-            raise ValueError('tally_index not available')
-        return self.config.tally_index
-    @tally_index.setter
-    def tally_index(self, value: int):
-        if not isinstance(self.config, SingleTallyConfig):
-            raise ValueError('tally_index not available')
-        if value == self.tally_index:
-            return
-        self.config.tally_index = value
-        self._tally_config_changed()
-
-    @property
-    def tally_type(self) -> TallyType:
-        """Alias for :attr:`~SingleTallyConfig.tally_type` of the :attr:`config`
-
-        Note:
-            Only valid if :attr:`config` is a :class:`SingleTallyConfig`
-        """
-        if not isinstance(self.config, SingleTallyConfig):
-            raise ValueError('tally_index not available')
-        return self.config.tally_type
-    @tally_type.setter
-    def tally_type(self, value: TallyType):
-        if not isinstance(self.config, SingleTallyConfig):
-            raise ValueError('tally_index not available')
-        if value == self.tally_type:
-            return
-        self._tally_config_changed()
-        self.config.tally_type = value
-
-    def _tally_config_changed(self):
-        """Called when changes to the :attr:`config` are made.
-
-        Subclasses can use this perform any necessary changes
-        :meta public:
-        """
-        pass
-
     async def open(self):
         """Initalize any necessary device communication
         """

--- a/src/tallypi/inputs/gpio.py
+++ b/src/tallypi/inputs/gpio.py
@@ -42,7 +42,7 @@ class GpioInput(BaseInput, namespace='gpio.GpioInput', final=True):
             return
         self.running = True
         self.screen, self.tally = self.config.create_tally()
-        self.tally = Tally(self.tally_index)
+        self.tally = Tally(self.config.tally_index)
         self.tally.bind(on_update=self._on_tallyobj_update)
         self.emit('on_screen_added', self, self.screen)
         self.emit('on_tally_added', self.tally)
@@ -81,14 +81,14 @@ class GpioInput(BaseInput, namespace='gpio.GpioInput', final=True):
             yield self.tally
 
     def _set_tally_state(self, state: bool):
-        attr = self.tally_type.name
+        attr = self.config.tally_type.name
         color = {True: TallyColor.RED, False: TallyColor.OFF}[state]
         setattr(self.tally, attr, color)
 
     def _on_tallyobj_update(self, tally: Tally, props_changed: Iterable[str], **kwargs):
-        if self.tally_type.name not in props_changed:
+        if self.config.tally_type.name not in props_changed:
             return
-        self.emit('on_tally_updated', [self.tally_type.name])
+        self.emit('on_tally_updated', [self.config.tally_type.name])
 
     def _on_button_pressed(self, button):
         if button is not self.button:

--- a/src/tallypi/outputs/gpio.py
+++ b/src/tallypi/outputs/gpio.py
@@ -89,7 +89,7 @@ class BaseLED(BaseOutput, namespace='gpio'):
     async def on_receiver_tally_change(self, tally: Tally, *args, **kwargs):
         if not self.running:
             return
-        if tally.index != self.tally_index:
+        if not self.tally_matches(tally):
             return
         color = getattr(tally, self.tally_type.name)
         brightness = tally.normalized_brightness

--- a/src/tallypi/outputs/gpio.py
+++ b/src/tallypi/outputs/gpio.py
@@ -91,7 +91,7 @@ class BaseLED(BaseOutput, namespace='gpio'):
             return
         if not self.tally_matches(tally):
             return
-        color = getattr(tally, self.tally_type.name)
+        color = getattr(tally, self.config.tally_type.name)
         brightness = tally.normalized_brightness
         self.set_led(color, brightness)
 

--- a/src/tallypi/outputs/rgbmatrix5x5.py
+++ b/src/tallypi/outputs/rgbmatrix5x5.py
@@ -186,7 +186,7 @@ class Matrix(Base, namespace='Matrix', final=True):
         for i in range(5):
             tally_index = self.start_index + i
             for j, ttype in enumerate(ttypes):
-                pixel = (i,j)
+                pixel = (j, i)
                 tconf = SingleTallyConfig(
                     screen_index=scr,
                     tally_index=tally_index,

--- a/src/tallypi/outputs/rgbmatrix5x5.py
+++ b/src/tallypi/outputs/rgbmatrix5x5.py
@@ -133,7 +133,7 @@ class Indicator(Base, namespace='Indicator', final=True):
             return
         if not self.tally_matches(tally):
             return
-        color = getattr(tally, self.tally_type.name)
+        color = getattr(tally, self.config.tally_type.name)
         if color != self._color:
             await self.set_color(color)
         brightness = tally.normalized_brightness

--- a/src/tallypi/outputs/rgbmatrix5x5.py
+++ b/src/tallypi/outputs/rgbmatrix5x5.py
@@ -145,8 +145,10 @@ class Indicator(Base, namespace='Indicator', final=True):
 class Matrix(Base, namespace='Matrix', final=True):
     """Show the status of up to 5 tallies in a matrix
 
-    The tallies are shown in rows beginning with
-    :attr:`~tallypi.common.BaseIO.tally_index` and ending with :attr:`end_index`.
+    The tallies are shown in 5 rows beginning with the
+    :attr:`~.common.SingleTallyConfig.tally_index`
+    of the :attr:`~.common.BaseIO.config`
+
     The columns show the individual :class:`~tslumd.common.TallyType` values
     ``('rh_tally', 'txt_tally', 'lh_tally')``
     """
@@ -162,29 +164,14 @@ class Matrix(Base, namespace='Matrix', final=True):
         self.update_queue = asyncio.Queue()
         self._update_task = None
 
-    @property
-    def start_index(self) -> int:
-        """The first tally index (the :attr:`~tallypi.common.SingleTallyConfig.tally_index`
-        of the :attr:`~tallypi.common.BaseIO.config`)
-        """
-        ix = self.config.tally_index
-        if ix is None:
-            ix = 0
-        return ix
-
-    @property
-    def end_index(self) -> int:
-        """The last tally index (derived from :attr:`start_index`)
-        """
-        return self.start_index + 4
-
     def build_multi_config(self) -> MultiTallyConfig:
         self.tally_type_map.clear()
         ttypes = [tt for tt in TallyType if tt != TallyType.no_tally]
         tconfs = []
         scr = self.config.screen_index
+        start_index = self.config.tally_index
         for i in range(5):
-            tally_index = self.start_index + i
+            tally_index = start_index + i
             for j, ttype in enumerate(ttypes):
                 pixel = (j, i)
                 tconf = SingleTallyConfig(

--- a/tests/test_tallyconfig.py
+++ b/tests/test_tallyconfig.py
@@ -7,7 +7,11 @@ def test_single_tally_matching():
         all_screens = SingleTallyConfig(
             screen_index=None, tally_index=i, tally_type=tally_type,
         )
+        assert all_screens.matches_screen(0xffff)
+
         for j in range(10):
+            assert all_screens.matches_screen(j)
+
             tconf0 = SingleTallyConfig(
                 screen_index=j, tally_index=i, tally_type=tally_type,
             )
@@ -20,6 +24,7 @@ def test_single_tally_matching():
             tconfs = [tconf0, tconf1, tconf2]
 
             for tconf in tconfs:
+                assert tconf.matches_screen(0xffff)
                 assert tconf.matches_screen(all_screens)
                 assert all_screens.matches_screen(tconf)
                 if tconf.tally_index == i:
@@ -28,7 +33,9 @@ def test_single_tally_matching():
                     assert not tconf.matches(all_screens)
 
             assert tconf0.matches_screen(tconf1)
+            assert tconf0.matches_screen(j)
             assert not tconf0.matches_screen(tconf2)
+            assert not tconf0.matches_screen(j+1)
             assert not tconf0.matches(tconf1)
             assert not tconf0.matches(tconf2)
 
@@ -49,6 +56,15 @@ def test_multi_tally_matching():
             screen_index=None, allow_all=True,
         )
 
+        assert tconf_broadcast.matches_screen(0xffff)
+        assert tconf_broadcast.matches_screen(i)
+        assert tconf_single_scr.matches_screen(i)
+
+        assert allow_all_bc_scr.matches_screen(0xffff)
+        assert allow_all_bc_scr.matches_screen(i)
+        assert allow_all_single_scr.matches_screen(i)
+        assert allow_all_single_scr.matches_screen(0xffff)
+
         assert allow_all_bc_scr.matches(tconf_broadcast)
         assert allow_all_bc_scr.matches(tconf_single_scr)
         assert allow_all_single_scr.matches(tconf_broadcast)
@@ -67,6 +83,10 @@ def test_multi_tally_matching():
             mconf1 = MultiTallyConfig(
                 screen_index=j+1, allow_all=True
             )
+
+            assert mconf0.matches_screen(0xffff)
+            assert mconf0.matches_screen(j)
+            assert not mconf0.matches_screen(j+1)
 
             assert mconf0.matches(tconf0)
             assert not mconf0.matches(tconf1)

--- a/tests/test_tallyconfig.py
+++ b/tests/test_tallyconfig.py
@@ -1,0 +1,83 @@
+from tslumd import TallyType, TallyKey, Tally
+from tallypi.common import SingleTallyConfig, MultiTallyConfig
+
+def test_single_tally_matching():
+    tally_type = TallyType.rh_tally
+    for i in range(10):
+        all_screens = SingleTallyConfig(
+            screen_index=None, tally_index=i, tally_type=tally_type,
+        )
+        for j in range(10):
+            tconf0 = SingleTallyConfig(
+                screen_index=j, tally_index=i, tally_type=tally_type,
+            )
+            tconf1 = SingleTallyConfig(
+                screen_index=j, tally_index=i+1, tally_type=tally_type,
+            )
+            tconf2 = SingleTallyConfig(
+                screen_index=j+1, tally_index=i, tally_type=tally_type,
+            )
+            tconfs = [tconf0, tconf1, tconf2]
+
+            for tconf in tconfs:
+                assert tconf.matches_screen(all_screens)
+                assert all_screens.matches_screen(tconf)
+                if tconf.tally_index == i:
+                    assert tconf.matches(all_screens)
+                else:
+                    assert not tconf.matches(all_screens)
+
+            assert tconf0.matches_screen(tconf1)
+            assert not tconf0.matches_screen(tconf2)
+            assert not tconf0.matches(tconf1)
+            assert not tconf0.matches(tconf2)
+
+def test_multi_tally_matching():
+    tally_type = TallyType.rh_tally
+    for i in range(10):
+        tally_index = i
+        tconf_broadcast = SingleTallyConfig(
+            screen_index=None, tally_index=tally_index, tally_type=tally_type,
+        )
+        tconf_single_scr = SingleTallyConfig(
+            screen_index=i, tally_index=tally_index, tally_type=tally_type,
+        )
+        allow_all_single_scr = MultiTallyConfig(
+            screen_index=i, allow_all=True,
+        )
+        allow_all_bc_scr = MultiTallyConfig(
+            screen_index=None, allow_all=True,
+        )
+
+        assert allow_all_bc_scr.matches(tconf_broadcast)
+        assert allow_all_bc_scr.matches(tconf_single_scr)
+        assert allow_all_single_scr.matches(tconf_broadcast)
+        assert allow_all_bc_scr.matches(tconf_broadcast)
+
+        for j in range(10):
+            tconf0 = SingleTallyConfig(
+                screen_index=j, tally_index=tally_index, tally_type=tally_type,
+            )
+            tconf1 = SingleTallyConfig(
+                screen_index=j+1, tally_index=tally_index, tally_type=tally_type,
+            )
+            mconf0 = MultiTallyConfig(
+                screen_index=j, allow_all=True,
+            )
+            mconf1 = MultiTallyConfig(
+                screen_index=j+1, allow_all=True
+            )
+
+            assert mconf0.matches(tconf0)
+            assert not mconf0.matches(tconf1)
+            assert mconf1.matches(tconf1)
+            assert not mconf1.matches(tconf0)
+
+            assert allow_all_bc_scr.matches(tconf0)
+            assert allow_all_bc_scr.matches(tconf1)
+
+            if i == j:
+                assert allow_all_single_scr.matches(tconf0)
+                assert not allow_all_single_scr.matches(tconf1)
+            else:
+                assert not allow_all_single_scr.matches(tconf0)


### PR DESCRIPTION
Refactor to work with changes in tslumd>=0.0.3  (nocarryr/tslumd#1).

Allow for subsets of tallies within their own screen objects and respect both "broadcast screen" and "broadcast tally" information